### PR TITLE
refactor: WORKSPACE_ROOTをcwd()デフォルトに変更し、エージェントがsrc/を編集可能にする

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -5,8 +5,6 @@ import { createModelFromEnv } from '../src/providers/modelFactory';
 import { readFile, writeFile, editFile, execCommand } from '../src/tools';
 import { createBranch, commitChanges, pushBranch } from '../src/tools/git';
 import { createPullRequest, createIssueComment } from '../src/tools/github';
-import { mkdirSync, existsSync } from 'fs';
-import { join } from 'path';
 import { config } from '../src/config';
 
 // 機密情報をマスクする（ログ出力用）
@@ -16,7 +14,7 @@ function maskSecret(value: string | undefined): string {
     return value.slice(0, 4) + '***' + value.slice(-4);
 }
 
-const WORKSPACE_ROOT = join(process.cwd(), 'workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 
 async function main() {
     const { values, positionals } = parseArgs({
@@ -60,11 +58,6 @@ async function main() {
     }
 
     // --- 環境設定 ---
-    
-    // ワークスペースディレクトリを作成
-    if (!existsSync(WORKSPACE_ROOT)) {
-        mkdirSync(WORKSPACE_ROOT, { recursive: true });
-    }
 
     const provider = process.env.LLM_PROVIDER;
     const modelName = process.env.LLM_MODEL;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,9 @@
 // src/config.ts
+import * as path from 'path';
+
 export let config = {
+    // ワークスペースルート（デフォルト: cwd = リポジトリルート）
+    workspaceRoot: path.resolve(process.env.NANO_CODE_WORKSPACE || process.cwd()),
     // Layer 2: プロセス隔離（bubblewrap）
     sandbox: false,
     // Layer 3: アプリケーション層の設定

--- a/src/tools/editFile.ts
+++ b/src/tools/editFile.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { config } from '../config';
 
-const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 
 async function editFileExecute(args: {
     path: string;

--- a/src/tools/execCommand.ts
+++ b/src/tools/execCommand.ts
@@ -1,8 +1,9 @@
 import { spawn } from 'child_process';
 import * as path from 'path';
 import type { Tool } from '../types';
+import { config } from '../config';
 
-const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 const ALLOWED_COMMANDS = ['bun', 'ls', 'cat', 'grep', 'find', 'pwd', 'mkdir', 'git', 'gh'];
 const MAX_OUTPUT_LENGTH = 2000;
 

--- a/src/tools/execCommandSandbox.ts
+++ b/src/tools/execCommandSandbox.ts
@@ -6,7 +6,7 @@ import { Sandbox } from '../core/sandbox';
 import { config } from '../config';
 import { parseCommand } from './execCommand';
 
-const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 const ALLOWED_COMMANDS = ['bun', 'ls', 'git', 'gh'];
 const MAX_OUTPUT_LENGTH = 2000;
 

--- a/src/tools/git.ts
+++ b/src/tools/git.ts
@@ -1,8 +1,9 @@
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { execCommand } from './execCommand';
+import { config } from '../config';
 
-const WORKSPACE_ROOT = join(process.cwd(), 'workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 
 function validateBranchName(name: string): void {
     if (!name || name.length > 120) {

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -1,8 +1,9 @@
 import { execCommand } from './execCommand';
 import { writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
+import { config } from '../config';
 
-const WORKSPACE_ROOT = join(process.cwd(), 'workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 
 function validateBranchName(name: string): void {
     if (!name || name.length > 120) {

--- a/src/tools/readFile.ts
+++ b/src/tools/readFile.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { config } from '../config';
 
-const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 const MAX_FILE_SIZE = 100 * 1024; // 100KB
 
 async function readFileExecute(args: { path: string }): Promise<string> {

--- a/src/tools/writeFile.ts
+++ b/src/tools/writeFile.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { config } from '../config';
 
-const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+const WORKSPACE_ROOT = config.workspaceRoot;
 
 async function writeFileExecute(args: {
     path: string;


### PR DESCRIPTION
## Summary
- 全ツールの`WORKSPACE_ROOT`を`config.workspaceRoot`に集約
- デフォルトを`process.cwd()`に変更（リポジトリルート全体が作業対象）
- `NANO_CODE_WORKSPACE=./workspace`で従来の制限付き動作も可能

## 動機
書籍レビューのIssue駆動デモで、nano-codeが自身のソースコード（`src/tools/execCommand.ts`等）を修正するIssueに対応できなかった。ワークスペースが`./workspace`に固定されており、`src/`配下が読み書き不可だったため。

## 変更点
- `src/config.ts`: `workspaceRoot`を追加（`NANO_CODE_WORKSPACE`環境変数 or `cwd()`）
- 7ツールファイル: ローカル定数を`config.workspaceRoot`への参照に統一
- `bin/cli.ts`: workspace mkdirを削除、config参照に変更

## 書籍本文との互換性
書籍4章・8章の「サンドボックス」の説明は`NANO_CODE_WORKSPACE=./workspace`で再現可能。パスチェックのロジック自体は変更なし。

Related: #20