### PR TITLE
docs: サポートサイトを技術文書向けにリニューアル (#22)

### DIFF
--- a/workspace/docs/index.html
+++ b/workspace/docs/index.html
@@ -23,76 +23,212 @@
         line-height: 1.8;
       }
       main {
-        max-width: 960px;
+        max-width: 1100px;
         margin: 0 auto;
-        padding: 56px 24px 40px;
+        padding: 40px 24px 40px;
       }
-      .hero, section, footer {
+      .hero, footer {
         background: var(--surface);
         border: 1px solid var(--border);
-        border-radius: 20px;
-        padding: 28px;
+        border-radius: 16px;
+        padding: 20px 24px;
       }
       .hero {
         display: grid;
-        gap: 24px;
+        gap: 20px;
         align-items: center;
-        grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
+        grid-template-columns: minmax(0, 100px) minmax(0, 1fr);
       }
       .hero h1 {
-        margin: 0 0 12px;
-        font-size: clamp(2rem, 4vw, 3.1rem);
-        line-height: 1.2;
+        margin: 0 0 8px;
+        font-size: clamp(1.5rem, 3vw, 2.2rem);
+        line-height: 1.25;
       }
-      p { margin: 0; }
+      .hero p { margin: 0; }
+      .hero p + p { margin-top: 6px; }
       a {
         color: var(--accent);
       }
       .badge {
         display: inline-block;
-        padding: 6px 12px;
+        padding: 4px 10px;
         border-radius: 999px;
         background: var(--accent-soft);
         color: var(--accent);
         font-weight: 700;
-        margin-bottom: 16px;
+        font-size: 0.8rem;
+        margin-bottom: 10px;
       }
       .cover {
-        width: 200px;
+        width: 100px;
         max-width: 100%;
         display: block;
-        border-radius: 12px;
+        border-radius: 8px;
         border: 1px solid var(--border);
-        box-shadow: 0 10px 24px rgba(0, 102, 204, 0.12);
+        box-shadow: 0 6px 16px rgba(0, 102, 204, 0.12);
       }
-      .grid {
+
+      .layout {
         display: grid;
-        gap: 20px;
-        margin-top: 24px;
+        grid-template-columns: 240px minmax(0, 1fr);
+        gap: 40px;
+        margin-top: 28px;
       }
-      h2 { margin: 0 0 16px; color: var(--accent); }
-      ul {
-        padding-left: 20px;
+      .toc {
+        position: sticky;
+        top: 24px;
+        align-self: start;
+      }
+      .toc h2 {
+        font-size: 1rem;
+        margin: 0 0 8px;
+        color: var(--accent);
+      }
+      .toc h3 {
+        margin: 16px 0 4px;
+        font-size: 0.85rem;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .toc ul {
+        list-style: none;
+        padding: 0;
         margin: 0;
       }
-      .chapters li { margin-bottom: 10px; }
-      .chapter {
+      .toc a {
+        display: block;
+        padding: 6px 10px;
+        border-radius: 6px;
+        color: var(--text);
+        text-decoration: none;
+        font-size: 0.9rem;
+        line-height: 1.5;
+      }
+      .toc a:hover {
+        background: var(--accent-soft);
         color: var(--accent);
+      }
+
+      .chapter-group {
+        margin-bottom: 32px;
+      }
+      .chapter-group > h2 {
+        margin: 0 0 16px;
+        padding-bottom: 8px;
+        border-bottom: 2px solid var(--border);
+        color: var(--accent);
+      }
+
+      article {
+        padding: 20px 24px;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        background: var(--surface);
+        margin-bottom: 16px;
+      }
+      article > header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+      article h3 {
+        margin: 0;
+        font-size: 1.1rem;
+        flex: 1;
+      }
+      .chapter-label {
+        display: inline-block;
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: var(--accent);
+        background: var(--accent-soft);
+        padding: 2px 10px;
+        border-radius: 999px;
+        letter-spacing: 0.04em;
+        white-space: nowrap;
+      }
+      .anchor {
+        opacity: 0;
+        color: var(--muted);
+        text-decoration: none;
         font-weight: 700;
       }
+      article:hover .anchor {
+        opacity: 1;
+      }
+
+      dl {
+        display: grid;
+        grid-template-columns: 7em 1fr;
+        gap: 8px 16px;
+        margin: 0;
+      }
+      dt {
+        color: var(--muted);
+        font-weight: 600;
+        font-size: 0.9rem;
+        padding-top: 2px;
+      }
+      dd {
+        margin: 0;
+      }
+      dd > p {
+        margin: 0 0 8px;
+      }
+      dd > p:last-child {
+        margin-bottom: 0;
+      }
+
+      code {
+        background: #f3f6fb;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.92em;
+        font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+      }
+      pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 14px 16px;
+        border-radius: 8px;
+        overflow-x: auto;
+        margin: 8px 0 0;
+      }
+      pre code {
+        background: transparent;
+        color: inherit;
+        padding: 0;
+        font-size: 0.88em;
+      }
+
       footer {
-        margin-top: 20px;
+        margin-top: 28px;
       }
       .footer-grid {
         display: grid;
-        gap: 12px;
+        gap: 10px;
       }
       .footer-note {
         color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      @media (max-width: 820px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+        .toc {
+          position: static;
+        }
       }
       @media (max-width: 640px) {
         .hero {
           grid-template-columns: 1fr;
+        }
+        .cover {
+          width: 120px;
         }
       }
     </style>
@@ -106,26 +242,228 @@
         <div>
           <div class="badge">Support Site</div>
           <h1>作って学ぶ AIエージェント サポートサイト</h1>
-          <p>このサイトは書籍「作って学ぶ AIエージェント ── TypeScriptとLLMで切り拓くAI時代のエンジニアリング」（laiso 著、技術評論社刊）のサポートサイトです</p>
+          <p>書籍「作って学ぶ AIエージェント ── TypeScriptとLLMで切り拓くAI時代のエンジニアリング」（laiso 著、技術評論社刊）のサポートサイトです。</p>
           <p><a href="https://gihyo.jp/book/2026/978-4-297-15565-0">技術評論社の書籍ページを見る</a></p>
         </div>
       </div>
 
-      <div class="grid">
-        <section>
+      <div class="layout">
+        <aside class="toc">
           <h2>補足情報</h2>
-          <ul class="chapters">
-            <li>
-              <span class="chapter">7.4節</span>：GitHub ActionsからPRを作成するには、ワークフロー権限（pull-requests: write）に加えて、リポジトリ設定で「Allow GitHub Actions to create and approve pull requests」を有効にする必要があります。設定が不足していると、ワークフロー実行時に「GitHub Actions is not permitted to create or approve pull requests」というエラーが発生します。対処するには、リポジトリの Settings → Actions → General → Workflow permissions を開き、該当項目にチェックを入れて Save してください。
-            </li>
-            <li>
-              <span class="chapter">7.7節</span>：Issue本文をCI向けプロンプトに埋め込む実装が必要です。ワークフローのYAMLで ISSUE_TEXT 環境変数に Issue 本文を渡していても、bin/cli.ts の issueDrivenInstructions がその内容を参照しなければ、エージェントは本文を読み取れません。症状としては、Issue トリガーで実行してもタイトルしか認識されず、詳細な指示に従えない状態になります。対処法として、issueDrivenInstructions のテンプレートリテラル内に process.env.ISSUE_TEXT を読み込んで「## Issue本文（参照用）」として埋め込んでください。例: const issueText = process.env.ISSUE_TEXT || ""; を用意し、${issueText} を挿入します。
-            </li>
-            <li>
-              <span class="chapter">7.2節</span>：Variables の設定漏れに注意してください。LLM_PROVIDER と LLM_MODEL は Secrets の LLM_API_KEY とは別に Variables として登録する必要があります。未登録の場合、ワークフローのログではこれらの値が空になり、bin/cli.ts 起動時に「LLM設定が不足しています」というエラーで終了します。対処法は、gh variable set LLM_PROVIDER --body "openai" と gh variable set LLM_MODEL --body "gpt-4o-mini" を実行し、gh variable list で登録状況を確認することです。
-            </li>
-          </ul>
-        </section>
+          <nav>
+            <h3>第 2 章</h3>
+            <ul>
+              <li><a href="#ch02-env-gemini">環境変数 GEMINI_API_KEY</a></li>
+            </ul>
+            <h3>第 3 章</h3>
+            <ul>
+              <li><a href="#ch03-3-llm-api-error">3.3 節 LLMApiError のコンストラクタ引数</a></li>
+            </ul>
+            <h3>第 4 章</h3>
+            <ul>
+              <li><a href="#ch04-6-tools-demo-filename">4.6 節 ツール動作確認スクリプトのファイル名</a></li>
+            </ul>
+            <h3>第 7 章</h3>
+            <ul>
+              <li><a href="#ch07-2-variables">7.2 節 Variables の設定</a></li>
+              <li><a href="#ch07-4-pr-permission">7.4 節 PR 作成の権限設定</a></li>
+              <li><a href="#ch07-7-issue-text">7.7 節 ISSUE_TEXT の埋め込み</a></li>
+            </ul>
+            <h3>第 8 章</h3>
+            <ul>
+              <li><a href="#ch08-3-bubblewrap-sys-admin">8.3 節 bubblewrap と SYS_ADMIN 権限</a></li>
+            </ul>
+          </nav>
+        </aside>
+
+        <div>
+          <section class="chapter-group">
+            <h2>第 2 章</h2>
+
+            <article id="ch02-env-gemini">
+              <header>
+                <span class="chapter-label">第 2 章</span>
+                <h3>環境変数 GEMINI_API_KEY</h3>
+                <a class="anchor" href="#ch02-env-gemini">#</a>
+              </header>
+              <dl>
+                <dt>本書の記載</dt>
+                <dd>
+                  <p>第 2 章の <code>.env</code> 例に <code>GOOGLE_API_KEY=AI...</code> が記載されています。第 6 章の <code>createModelFromEnv</code> の実装でも <code>process.env.GOOGLE_API_KEY</code> を参照する形で説明されています。</p>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p><code>@google/genai</code> SDK が参照する標準の環境変数名は <code>GEMINI_API_KEY</code> です。<code>GOOGLE_API_KEY</code> だけを設定した場合、SDK からは空と判定されます。</p>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p><code>.env</code> には <code>GEMINI_API_KEY</code> を設定します。本リポジトリの <code>src/providers/google.ts</code> は <code>GEMINI_API_KEY ?? GOOGLE_API_KEY</code> のフォールバックを備えているため両方の環境変数名を受け付けますが、新規設定では <code>GEMINI_API_KEY</code> を使用してください。</p>
+                  <pre><code>GEMINI_API_KEY=AI...</code></pre>
+                </dd>
+              </dl>
+            </article>
+          </section>
+
+          <section class="chapter-group">
+            <h2>第 3 章</h2>
+
+            <article id="ch03-3-llm-api-error">
+              <header>
+                <span class="chapter-label">3.3 節</span>
+                <h3>LLMApiError のコンストラクタ引数</h3>
+                <a class="anchor" href="#ch03-3-llm-api-error">#</a>
+              </header>
+              <dl>
+                <dt>本書の記載</dt>
+                <dd>
+                  <p>OpenAI プロバイダーの例で次の呼び出しが記載されています。</p>
+                  <pre><code>throw new LLMApiError('APIからの応答がありません');</code></pre>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p><code>LLMApiError</code> クラスの定義では第 1 引数が <code>status: number</code>、第 2 引数が <code>provider: string</code> で、文字列 1 つだけを渡す呼び出しは型エラーになります。</p>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p>多引数形式で呼び出します。</p>
+                  <pre><code>throw new LLMApiError(500, 'openai', undefined, 'APIからの応答がありません');</code></pre>
+                </dd>
+              </dl>
+            </article>
+          </section>
+
+          <section class="chapter-group">
+            <h2>第 4 章</h2>
+
+            <article id="ch04-6-tools-demo-filename">
+              <header>
+                <span class="chapter-label">4.6 節</span>
+                <h3>ツール動作確認スクリプトのファイル名</h3>
+                <a class="anchor" href="#ch04-6-tools-demo-filename">#</a>
+              </header>
+              <dl>
+                <dt>本書の記載</dt>
+                <dd>
+                  <p>コード例のコメントに <code>// chapters/04-tools-demo.ts</code> とあり、実行コマンドの例は <code>bun run chapters/04-demo-tools.ts</code> と記載されています。</p>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p>実行コマンドのファイル名がコード例と一致していないため、記載どおりに実行するとファイルが見つからずエラーになります。</p>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p>正しいファイル名は <code>04-tools-demo.ts</code> です。次のコマンドで実行してください。</p>
+                  <pre><code>bun run chapters/04-tools-demo.ts</code></pre>
+                </dd>
+              </dl>
+            </article>
+          </section>
+
+          <section class="chapter-group">
+            <h2>第 7 章</h2>
+
+            <article id="ch07-2-variables">
+              <header>
+                <span class="chapter-label">7.2 節</span>
+                <h3>Variables の設定</h3>
+                <a class="anchor" href="#ch07-2-variables">#</a>
+              </header>
+              <dl>
+                <dt>本書の記載</dt>
+                <dd>
+                  <p><code>gh variable set</code> による <code>LLM_PROVIDER</code> と <code>LLM_MODEL</code> の登録手順が記載されています。</p>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p>Variables が未登録の場合、ワークフロー実行時にこれらの環境変数が空となり、<code>bin/cli.ts</code> 起動時に「LLM設定が不足しています」のエラーで終了します。Secrets の <code>LLM_API_KEY</code> とは別に Variables として登録する必要があります。</p>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p>次のコマンドで Variables を登録します。登録状況は <code>gh variable list</code> で確認できます。</p>
+                  <pre><code>gh variable set LLM_PROVIDER --body "openai"
+gh variable set LLM_MODEL --body "gpt-5-mini"</code></pre>
+                </dd>
+              </dl>
+            </article>
+
+            <article id="ch07-4-pr-permission">
+              <header>
+                <span class="chapter-label">7.4 節</span>
+                <h3>PR 作成の権限設定</h3>
+                <a class="anchor" href="#ch07-4-pr-permission">#</a>
+              </header>
+              <dl>
+                <dt>本書の記載</dt>
+                <dd>
+                  <p>7.4 節でワークフロー権限 <code>pull-requests: write</code> の設定手順が記載されています。</p>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p>ワークフロー権限だけではプルリクエストを作成できず、実行時に次のエラーで失敗します。</p>
+                  <pre><code>GitHub Actions is not permitted to create or approve pull requests</code></pre>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p>リポジトリの Settings → Actions → General → Workflow permissions を開き、「Allow GitHub Actions to create and approve pull requests」にチェックを入れて Save してください。ワークフロー権限の設定と併用することで、プルリクエストの作成が許可されます。</p>
+                </dd>
+              </dl>
+            </article>
+
+            <article id="ch07-7-issue-text">
+              <header>
+                <span class="chapter-label">7.7 節</span>
+                <h3>ISSUE_TEXT の埋め込み</h3>
+                <a class="anchor" href="#ch07-7-issue-text">#</a>
+              </header>
+              <dl>
+                <dt>本書の記載</dt>
+                <dd>
+                  <p>ワークフロー YAML で <code>ISSUE_TEXT</code> 環境変数に Issue 本文を渡す設定が記載されています。</p>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p><code>bin/cli.ts</code> の <code>issueDrivenInstructions</code> テンプレートが <code>ISSUE_TEXT</code> を参照しない構成の場合、エージェントは Issue タイトルしか認識できず、本文の詳細な指示に従えません。</p>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p><code>issueDrivenInstructions</code> のテンプレートリテラル内で <code>process.env.ISSUE_TEXT</code> を取り込み、「## Issue本文（参照用）」の形で本文を埋め込みます。</p>
+                  <pre><code>const issueText = process.env.ISSUE_TEXT || '';
+const issueDrivenInstructions = `${baseInstructions}
+
+## Issue本文（参照用）
+${issueText}
+`;</code></pre>
+                </dd>
+              </dl>
+            </article>
+          </section>
+
+          <section class="chapter-group">
+            <h2>第 8 章</h2>
+
+            <article id="ch08-3-bubblewrap-sys-admin">
+              <header>
+                <span class="chapter-label">8.3 節</span>
+                <h3>bubblewrap と SYS_ADMIN 権限</h3>
+                <a class="anchor" href="#ch08-3-bubblewrap-sys-admin">#</a>
+              </header>
+              <dl>
+                <dt>本書の記載</dt>
+                <dd>
+                  <p>bubblewrap の実行に <code>--cap-add=SYS_ADMIN</code> が必要と記載されています。</p>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p>全ての環境でこのオプションが必須とは限りません。</p>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p>ホストのカーネル設定 <code>kernel.unprivileged_userns_clone=1</code> が有効な環境では、<code>--cap-add=SYS_ADMIN</code> なしで bubblewrap を起動できる場合があります。実行環境のカーネル設定を確認のうえ、必要に応じてオプションを付与してください。</p>
+                </dd>
+              </dl>
+            </article>
+          </section>
+        </div>
       </div>
 
       <footer>


### PR DESCRIPTION
## Summary
- `workspace/docs/index.html` を技術文書向けの構造にリニューアル
- 左サイドバー目次（sticky、章別グルーピング）を追加
- 各補足項目を `<article>` + `<dl>`（本書の記載 / 症状 / 対処）構造に再編
- コマンド・コード片を `<code>` / `<pre>` で視覚的に分離
- 新規 4 項目を追加し、既存 3 項目と合わせて計 7 項目に拡充

## 追加項目
- 第 2 章: 環境変数 GEMINI_API_KEY
- 第 3 章 3.3 節: LLMApiError のコンストラクタ引数
- 第 4 章 4.6 節: ツール動作確認スクリプトのファイル名
- 第 8 章 8.3 節: bubblewrap と SYS_ADMIN 権限

## 既存 3 項目（新構造で書き直し）
- 第 7 章 7.2 節: Variables の設定
- 第 7 章 7.4 節: PR 作成の権限設定
- 第 7 章 7.7 節: ISSUE_TEXT の埋め込み

Closes #22

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>