### PR TITLE
fix: Issue駆動CIプロンプトを書籍 ch07 7.6 節に整合させPR作成まで完走させる

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -117,16 +117,31 @@ async function main() {
 
     const issueText = process.env.ISSUE_TEXT || '';
     const issueDrivenInstructions = `${baseInstructions}
-
-## CI向け追加指示
-あなたは GitHub Actions で実行される TypeScript コーディングエージェントです。Issue番号は ${process.env.ISSUE_NUMBER || '(なし)'} です（「(なし)」ならコメントは不要）。
+あなたは GitHub Actions で実行される TypeScript コーディングエージェントです。
+現在の環境は CI 環境であり、あなたの仕事はコードを修正してプルリクエストを作成することです。
+トリガーとなった Issue 番号は ${process.env.ISSUE_NUMBER || '(なし)'} です（もし「(なし)」ならコメントは不要）。
 
 ## Issue本文（参照用）
 ${issueText}
 
-- 作業を始める前に、必ずTODOリストを作成する。
-- 次の順番で作業する: Issue理解 → ファイル読込 → 修正 → テスト → Gitコミット/プッシュ → PR作成 → Issueへ結果コメント。
-- レポートは日本語で行うこと。`;
+## ワークフロー
+以下の手順で作業を進めてください：
+
+1. **TODOリストの作成**: Issueの内容に基づき、以下の項目を含むTODOリストを作成する。
+   - [ ] Issue を理解する
+   - [ ] 対象ファイルを読み込む
+   - [ ] コードを修正する
+   - [ ] 修正結果をテストする
+   - [ ] Git にコミットしてプッシュする
+   - [ ] プルリクエストを作成する
+   - [ ] 元の Issue にコメントで報告する
+
+2. **タスクの実行**: TODOリストに従って作業を進める。
+   - **重要**: ファイルを修正しただけでは終了ではない。必ず Git コミット、プッシュ、プルリクエスト作成まで行うこと。
+   - 最後に createIssueComment を使い、作成したプルリクエストのURLを元のIssueに投稿すること。
+
+3. **完了報告**: すべてのTODOが完了したら、結果をまとめる。
+`;
 
     const agent = new Agent({
         name: 'nano-code',


### PR DESCRIPTION
## Summary
- `bin/cli.ts` の `issueDrivenInstructions` を書籍 ch07 7.6 節の記述に合わせて強化
- 7 項目の TODO チェックボックステンプレ・「**重要**: ファイル修正だけで終わるな」の強調・`createIssueComment` の名指し指示を導入
- ch07-7 補足の `## Issue本文（参照用）` 埋め込みは維持

## 背景
従来の CI 向け追加指示は 1 行のステップ羅列(`Issue理解 → ファイル読込 → 修正 → テスト → Gitコミット/プッシュ → PR作成 → Issueへ結果コメント`)で、ベース指示 (`src/core/prompt.md`) の「必ず以下の形式で TODO リストを作成してください」+ 4 項目テンプレートに押し負けていた。

結果として `gpt-5-nano` 等の小型モデルでは 4 項目テンプレ(タスク理解/ファイル読込/変更/動作確認)をそのまま採用し、ファイル修正とテスト実行を終えた段階で「正常終了」してしまい、`createBranch` / `commitChanges` / `pushBranch` / `createPullRequest` / `createIssueComment` ツールが一度も呼ばれずに完了する事象が発生していた(参考: TM-DataScientist/nano-code の Actions ログ)。

書籍 ch07 7.6 節 (`manuscript/ch07_github_actions/ch07_GitHub Actionsで開発ワークフローを自動化する.md:378-400`) には PR 作成まで完走する強いプロンプトが既に掲載されており、実装を書籍に整合させる修正。

## Test plan
- [ ] ローカルで \`LLM_PROVIDER=openai LLM_MODEL=gpt-5-nano LLM_API_KEY=… ISSUE_TEXT="calculator.ts にテストを追加" ISSUE_NUMBER=999 bun run bin/cli.ts --yolo\` を実行し、TODO が 7 項目で出力されることを確認
- [ ] \`gh workflow run nano-code.yml -f task="calculator.ts にテストを追加して"\` で Actions 上の手動トリガーから PR 作成まで到達することを確認
- [ ] Issue を新規作成して自動トリガー経由でも PR 作成 + Issue コメント投稿まで完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)