### PR TITLE
第4章の書籍記述との整合性向上とセキュリティ強化、サポートサイトの更新

### DIFF
--- a/chapters/04-tools-demo.ts
+++ b/chapters/04-tools-demo.ts
@@ -1,65 +1,62 @@
-import { readFile } from '../src/tools/readFile';
 import { writeFile } from '../src/tools/writeFile';
+import { readFile } from '../src/tools/readFile';
+import { editFile } from '../src/tools/editFile';
 import { execCommand } from '../src/tools/execCommand';
-import * as path from 'path';
-import * as fs from 'fs/promises';
 
-async function main() {
-    console.log('--- Starting Tools Demo ---\n');
+async function demo() {
+  console.log('=== ツール動作確認 ===\n');
 
-    // ワークスペースディレクトリが存在することを確認
-    const workspaceDir = path.resolve(process.cwd(), 'workspace');
-    await fs.mkdir(workspaceDir, { recursive: true });
+  // 1. writeFile: ファイルを作成
+  console.log('1. writeFile: テストファイルを作成');
+  const writeResult = await writeFile.execute({
+    path: 'test.txt',
+    content: 'Hello from Nano Code!\nThis is a test file.',
+  });
+  console.log(`   結果: ${writeResult}\n`);
 
-    // 1. Test writeFile
-    console.log('1. Testing writeFile...');
-    try {
-        const result = await writeFile.execute({
-            path: 'hello.txt',
-            content: 'Hello from NanoCode Tools!'
-        });
-        console.log('✅ writeFile success:', result);
-    } catch (error: any) {
-        console.error('❌ writeFile failed:', error.message);
-    }
+  // 2. readFile: 作成したファイルを読み込み
+  console.log('2. readFile: 作成したファイルを読み込み');
+  const content = await readFile.execute({ path: 'test.txt' });
+  console.log(`   内容:\n   ${content.replace(/\n/g, '\n   ')}\n`);
 
-    // 2. Test readFile
-    console.log('\n2. Testing readFile...');
-    try {
-        const content = await readFile.execute({ path: 'hello.txt' });
-        console.log('✅ readFile success:', content);
-    } catch (error: any) {
-        console.error('❌ readFile failed:', error.message);
-    }
+  // 3. editFile: ファイルの一部を編集
+  console.log('3. editFile: ファイルの一部を編集');
+  const editResult = await editFile.execute({
+    path: 'test.txt',
+    oldText: 'Hello from Nano Code!',
+    newText: 'Hello from Nano Code Agent!',
+  });
+  console.log(`   結果: ${editResult}\n`);
 
-    // 3. Test execCommand (ls)
-    console.log('\n3. Testing execCommand (ls)...');
-    try {
-        const output = await execCommand.execute({ command: 'ls -l' });
-        console.log('✅ execCommand success:\n', output);
-    } catch (error: any) {
-        console.error('❌ execCommand failed:', error.message);
-    }
+  // 4. readFile: 編集後のファイルを確認
+  console.log('4. readFile: 編集後のファイルを確認');
+  const editedContent = await readFile.execute({ path: 'test.txt' });
+  console.log(`   内容:\n   ${editedContent.replace(/\n/g, '\n   ')}\n`);
 
-    // 4. Test Security (Path Traversal)
-    console.log('\n4. Testing Security (Path Traversal)...');
-    try {
-        await readFile.execute({ path: '../package.json' });
-        console.error('❌ Security check failed: Should not be able to read outside workspace');
-    } catch (error: any) {
-        console.log('✅ Security check passed:', error.message);
-    }
+  // 5. execCommand: ワークスペースのファイル一覧
+  console.log('5. execCommand: ワークスペースのファイル一覧');
+  const lsResult = await execCommand.execute({ command: 'ls -la' });
+  console.log(`   結果:\n${lsResult}\n`);
 
-    // 5. Test Security (Command Injection)
-    console.log('\n5. Testing Security (Command Injection)...');
-    try {
-        await execCommand.execute({ command: 'ls; rm -rf /' });
-        console.error('❌ Security check failed: Should not execute injected command');
-    } catch (error: any) {
-        console.log('✅ Security check passed:', error.message);
-    }
+  // 6. エラーケース: 存在しないファイルの読み込み
+  console.log('6. エラーケース: 存在しないファイルの読み込み');
+  try {
+    await readFile.execute({ path: 'nonexistent.txt' });
+  } catch (error) {
+    // strictモードのビルドエラー回避のため as any を使用
+    console.log(`   期待どおりのエラー: ${(error as any).message}\n`);
+  }
 
-    console.log('\n--- Tools Demo Completed ---');
+  // 7. セキュリティチェック: ワークスペース外へのアクセス
+  console.log('7. セキュリティチェック: ワークスペース外へのアクセス');
+  try {
+    await readFile.execute({ path: '../.env' });
+  } catch (error) {
+    // strictモードのビルドエラー回避のため as any を使用
+    console.log(`   期待どおりのエラー: ${(error as any).message}\n`);
+  }
+
+  console.log('=== 動作確認完了 ===');
 }
 
-main().catch(console.error);
+demo().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "agent": "bun run bin/cli.ts",
     "action": "bun run bin/action.ts",
-    "test": "bun test workspace/calculator.test.ts src/core/generate-text.test.ts src/core/generate-stream.test.ts"
+    "test": "bun test"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/src/tools/editFile.test.ts
+++ b/src/tools/editFile.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { editFile } from './editFile';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+
+describe('editFile Tool', () => {
+    const testFileName = 'test-edit-file.txt';
+    const testFilePath = path.join(WORKSPACE_ROOT, testFileName);
+    const initialContent = 'line 1: AAA\nline 2: BBB\nline 3: AAA\n';
+
+    beforeEach(async () => {
+        await fs.mkdir(WORKSPACE_ROOT, { recursive: true });
+        await fs.writeFile(testFilePath, initialContent, 'utf-8');
+    });
+
+    afterEach(async () => {
+        try {
+            await fs.unlink(testFilePath);
+        } catch {}
+    });
+
+    it('should edit file text successfully if target matches exactly once', async () => {
+        const result = await editFile.execute({
+            path: testFileName,
+            oldText: 'line 2: BBB',
+            newText: 'line 2: CCC'
+        });
+
+        expect(result).toContain('ファイルを編集しました');
+        const content = await fs.readFile(testFilePath, 'utf-8');
+        expect(content).toBe('line 1: AAA\nline 2: CCC\nline 3: AAA\n');
+    });
+
+    it('should throw an error if target text is not found', async () => {
+        await expect(editFile.execute({
+            path: testFileName,
+            oldText: 'line X: ZZZ',
+            newText: 'line X: YYY'
+        })).rejects.toThrow('変更対象が見つかりません');
+    });
+
+    it('should throw an error if target text matches multiple times', async () => {
+        await expect(editFile.execute({
+            path: testFileName,
+            oldText: 'AAA',
+            newText: 'XXX'
+        })).rejects.toThrow('複数の候補が見つかりました');
+    });
+
+    it('should block editing file outside workspace (Path Traversal)', async () => {
+        await expect(editFile.execute({
+            path: '../outside.txt',
+            oldText: 'AAA',
+            newText: 'XXX'
+        })).rejects.toThrow('アクセス拒否');
+    });
+
+    it('should block editing file through symbolic link pointing outside workspace', async () => {
+        const symlinkName = 'bad-edit-symlink.txt';
+        const symlinkPath = path.join(WORKSPACE_ROOT, symlinkName);
+        const targetPath = path.resolve(process.cwd(), './package.json');
+
+        try {
+            await fs.symlink(targetPath, symlinkPath);
+            await expect(editFile.execute({
+                path: symlinkName,
+                oldText: 'AAA',
+                newText: 'XXX'
+            })).rejects.toThrow('アクセス拒否');
+        } finally {
+            try {
+                await fs.unlink(symlinkPath);
+            } catch {}
+        }
+    });
+});

--- a/src/tools/editFile.ts
+++ b/src/tools/editFile.ts
@@ -4,52 +4,82 @@ import * as path from 'path';
 const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
 
 async function editFileExecute(args: {
-    path: string;
-    oldText: string;
-    newText: string;
+  path: string;
+  oldText: string;  // 変更前のテキスト（必須）
+  newText: string;  // 変更後のテキスト
 }): Promise<string> {
-    const absolutePath = path.resolve(WORKSPACE_ROOT, args.path);
+  // ステップ1: 相対パスを絶対パスに変換
+  const absolutePath = path.resolve(WORKSPACE_ROOT, args.path);
 
-    const allowedPrefix = WORKSPACE_ROOT + path.sep;
-    if (!absolutePath.startsWith(allowedPrefix) && absolutePath !== WORKSPACE_ROOT) {
-        throw new Error(`アクセス拒否: ${args.path} はワークスペース外です`);
+  // ステップ2: ワークスペース内かチェック（ディレクトリトラバーサル対策）
+  const allowedPrefix = WORKSPACE_ROOT + path.sep;
+  if (!absolutePath.startsWith(allowedPrefix) && absolutePath !== WORKSPACE_ROOT) {
+    throw new Error(`アクセス拒否: ${args.path} はワークスペース外です`);
+  }
+
+  // 【実用上のセキュリティ強化】
+  // 本書に記載の文字列比較（startsWith）のみでは、ワークスペース内に外部を指す
+  // シンボリックリンクが存在する場合にトラバーサルを許してしまう制限があります。
+  // そのため、ここではファイル読み込み前に実体パス（fs.realpath）を解決し、ワークスペース内であることを検証します。
+  let realPath: string;
+  try {
+    realPath = await fs.realpath(absolutePath);
+  } catch (error) {
+    if ((error as any).code === 'ENOENT') {
+      throw new Error(`ファイルが見つかりません: ${args.path}`);
     }
+    throw error;
+  }
+  if (!realPath.startsWith(allowedPrefix) && realPath !== WORKSPACE_ROOT) {
+    throw new Error(`アクセス拒否: ${args.path} はシンボリックリンク経由でワークスペース外を参照しています`);
+  }
 
-    const content = await fs.readFile(absolutePath, 'utf-8');
-    const matches = content.split(args.oldText).length - 1;
+  // ステップ3: ファイルを読み込む
+  const content = await fs.readFile(absolutePath, 'utf-8');
 
-    if (matches === 0) {
-        throw new Error(`変更対象が見つかりません: ${args.oldText.slice(0, 50)}...`);
-    }
-    if (matches > 1) {
-        throw new Error(`複数の候補が見つかりました（${matches}箇所）。より具体的な範囲を指定してください`);
-    }
+  // ステップ4: あいまい性チェック（変更対象が一意に特定できるか確認）
+  const matches = content.split(args.oldText).length - 1;
+  if (matches === 0) {
+    const preview = args.oldText.length > 50
+      ? `${args.oldText.slice(0, 50)}...`
+      : args.oldText;
+    throw new Error(`変更対象が見つかりません: ${preview}`);
+  }
+  if (matches > 1) {
+    throw new Error(
+      `複数の候補が見つかりました（${matches}箇所）。より具体的な範囲を指定してください`
+    );
+  }
 
-    const backupPath = `${absolutePath}.backup`;
-    await fs.copyFile(absolutePath, backupPath);
+  // ステップ5: テキストを検索・置換して書き込み
+  const newContent = content.replace(args.oldText, args.newText);
+  await fs.writeFile(absolutePath, newContent, 'utf-8');
 
-    const newContent = content.replace(args.oldText, args.newText);
-    await fs.writeFile(absolutePath, newContent, 'utf-8');
-
-    return `ファイルを編集しました: ${args.oldText.slice(0, 30)}... → ${args.newText.slice(0, 30)}...`;
+  return `ファイルを編集しました: ${args.oldText.slice(0, 30)}... → ${args.newText.slice(0, 30)}...`;
 }
 
 export const editFile = {
-    name: 'editFile',
-    description:
-        'ファイルの一部を編集する。oldTextで指定した箇所をnewTextに置き換える。oldTextが複数見つかる場合はエラーを返すため、一意に特定できる範囲を指定すること。ファイル全体を読み書きするよりトークン消費が少ない。',
-    needsApproval: true,
-    parameters: {
-        type: 'object',
-        properties: {
-            path: { type: 'string', description: '編集するファイルのパス' },
-            oldText: {
-                type: 'string',
-                description: '変更前のテキスト（一意に特定できる範囲を指定）',
-            },
-            newText: { type: 'string', description: '変更後のテキスト' },
-        },
-        required: ['path', 'oldText', 'newText'],
+  name: "editFile",
+  description: "ファイルの一部を編集する。oldTextで指定した箇所をnewTextに置き換える。oldTextが複数見つかる場合はエラーを返すため、一意に特定できる範囲を指定すること。ファイル全体を読み書きするよりトークン消費が少ない。",
+  // ツール実行時に人間の承認が必要かどうか（第5章で使用）
+  needsApproval: true,
+  parameters: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "編集するファイルのパス"
+      },
+      oldText: {
+        type: "string",
+        description: "変更前のテキスト（一意に特定できる範囲を指定）"
+      },
+      newText: {
+        type: "string",
+        description: "変更後のテキスト"
+      }
     },
-    execute: editFileExecute,
+    required: ["path", "oldText", "newText"]
+  },
+  execute: editFileExecute
 };

--- a/src/tools/execCommand.test.ts
+++ b/src/tools/execCommand.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'bun:test';
+import { execCommand } from './execCommand';
+
+describe('execCommand Tool', () => {
+    it('should run allowed command successfully', async () => {
+        const result = await execCommand.execute({ command: 'ls' });
+        expect(result).toBeDefined();
+        expect(typeof result).toBe('string');
+    });
+
+    it('should block command not in allowed list', async () => {
+        await expect(execCommand.execute({ command: 'whoami' }))
+            .rejects.toThrow('許可されていません');
+    });
+
+    it('should block command containing dangerous characters (command injection)', async () => {
+        await expect(execCommand.execute({ command: 'ls; whoami' }))
+            .rejects.toThrow('シェルメタ文字を含むコマンドは実行できません');
+        await expect(execCommand.execute({ command: 'ls & whoami' }))
+            .rejects.toThrow('シェルメタ文字を含むコマンドは実行できません');
+        await expect(execCommand.execute({ command: 'ls `whoami`' }))
+            .rejects.toThrow('シェルメタ文字を含むコマンドは実行できません');
+        await expect(execCommand.execute({ command: 'ls $(whoami)' }))
+            .rejects.toThrow('シェルメタ文字を含むコマンドは実行できません');
+        await expect(execCommand.execute({ command: 'ls | whoami' }))
+            .rejects.toThrow('シェルメタ文字を含むコマンドは実行できません');
+    });
+
+    it('should block dangerous pattern commands', async () => {
+        await expect(execCommand.execute({ command: 'bun run --help rm -rf' }))
+            .rejects.toThrow('危険なコマンドパターンが検出されました');
+    });
+
+    it('should block command with dangerous options', async () => {
+        // find -exec の検知 (メタ文字セミコロンを含むためメタ文字エラーになる)
+        await expect(execCommand.execute({ command: 'find . -exec rm -rf {} \\;' }))
+            .rejects.toThrow('シェルメタ文字を含むコマンドは実行できません');
+        // find -delete の検知
+        await expect(execCommand.execute({ command: 'find . -delete' }))
+            .rejects.toThrow('危険なコマンドパターンが検出されました');
+        // git --git-dir の検知
+        await expect(execCommand.execute({ command: 'git --git-dir=../.git status' }))
+            .rejects.toThrow('危険なコマンドパターンが検出されました');
+        // git --work-tree の検知
+        await expect(execCommand.execute({ command: 'git --work-tree=/tmp status' }))
+            .rejects.toThrow('危険なコマンドパターンが検出されました');
+    });
+
+    it('should block arguments referencing path outside workspace', async () => {
+        await expect(execCommand.execute({ command: 'ls ../' }))
+            .rejects.toThrow('アクセス拒否');
+        await expect(execCommand.execute({ command: 'ls /etc' }))
+            .rejects.toThrow('アクセス拒否');
+    });
+
+    it('should throw an error on command failure (non-zero exit code)', async () => {
+        // ls で存在しないファイルを指定して強制終了コードを発生させる
+        await expect(execCommand.execute({ command: 'ls non-existent-file-xyz' }))
+            .rejects.toThrow('コマンドが異常終了しました');
+    });
+});

--- a/src/tools/execCommand.ts
+++ b/src/tools/execCommand.ts
@@ -2,18 +2,35 @@ import { spawn } from 'child_process';
 import * as path from 'path';
 import type { Tool } from '../types';
 
+// ワークスペースのルートディレクトリ
 const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+
+// 許可されたコマンド
+// 本書では ['bun', 'ls', 'git', 'gh'] だが、後続の章でエージェントが
+// cat/grep/find/pwd/mkdir などを多用して自律動作するため許可コマンドを追加。
 const ALLOWED_COMMANDS = ['bun', 'ls', 'cat', 'grep', 'find', 'pwd', 'mkdir', 'git', 'gh'];
-const MAX_OUTPUT_LENGTH = 2000;
+
+// 出力サイズの上限（文字数）
+const MAX_OUTPUT_LENGTH = 2048; // 本書の 2048 文字制限に揃える
+
+// 危険な文字の正規表現
+const dangerousChars = /[;&`$|]/;
 
 type Quote = '"' | "'" | null;
+
+// Google (Gemini) や Anthropic の Function Calling で、
+// LLMが引数をオブジェクト（commandName, commandArgs）で返してくるケースに対応するための機能拡張。
+// ※本書のスキーマ定義（commandプロパティのみを要求する形）と整合させつつ、一部のプロバイダー（SDK）の
+//   挙動の違いを安全に吸収するための、配布リポジトリ独自の内部的な互換処理です。
 type ExecCommandInput = {
     command?: unknown;
     commandName?: unknown;
     commandArgs?: unknown;
 };
 
-// 引用符付き引数をサポートする最小限のコマンドパーサ
+// ============================
+// parseCommand：コマンド文字列の解析（Bash互換パーサ）
+// ============================
 export function parseCommand(input: string): string[] {
     const tokens: string[] = [];
     let current = '';
@@ -23,6 +40,7 @@ export function parseCommand(input: string): string[] {
     for (let i = 0; i < input.length; i++) {
         const ch = input[i] as string;
 
+        // クォート内の処理
         if (quote) {
             if (escaped) {
                 current += ch;
@@ -56,11 +74,13 @@ export function parseCommand(input: string): string[] {
             continue;
         }
 
+        // クォート開始
         if (ch === '"' || ch === "'") {
             quote = ch;
             continue;
         }
 
+        // 空白で分割
         if (/\s/.test(ch)) {
             if (current.length > 0) {
                 tokens.push(current);
@@ -83,19 +103,32 @@ export function parseCommand(input: string): string[] {
     return tokens;
 }
 
+// ============================
+// execCommandExecute：安全なコマンド実行
+// ============================
+// 【本書の記述との差異】
+// 本文で紹介している execCommand の実装はシンプルですが、本コードでは以下の堅牢化を行っています：
+// 1. 引数のオブジェクト対応：GeminiやAnthropicで引数が commandName / commandArgs で返るケースをサポート
+// 2. 危険コマンド検知：rm -rf や curl|sh などの破壊的コマンドを事前にブロック（dangerousPatterns）
+// 3. 厳格なパス検証：引数の相対パスや絶対パスによるワークスペース外へのアクセス防御を強化
+// 4. コマンド失敗時の例外スロー：終了コード非ゼロ時に reject(new Error) してエージェントに失敗を認識させる
+// ※なお、4.5節の解説スニペットでは関数名が execCommand となっていますが、オブジェクト名との名前衝突を
+//   避けるため、本書の最終コードと同様に execCommandExecute と命名しています。
 async function execCommandExecute(args: Record<string, unknown>): Promise<string> {
     const input = args as ExecCommandInput;
     let commandName = '';
     let commandArgs: string[] = [];
     let commandForCheck = '';
 
+    // コマンド引数の解析
     if (typeof input.command === 'string') {
         const command = input.command;
-        const dangerousChars = /[;&`$]/;
+        // 1. 危険文字チェック
         if (dangerousChars.test(command)) {
             throw new Error('セキュリティ上の理由により、シェルメタ文字を含むコマンドは実行できません');
         }
 
+        // 2. コマンドの解析
         const parts = parseCommand(command);
         commandName = parts[0] || '';
         commandArgs = parts.slice(1);
@@ -117,18 +150,39 @@ async function execCommandExecute(args: Record<string, unknown>): Promise<string
         throw new Error('コマンドが空です');
     }
 
+    // 3. ホワイトリストチェック
     if (!ALLOWED_COMMANDS.includes(commandName)) {
         throw new Error(`コマンド ${commandName} は許可されていません`);
     }
 
-    const dangerousPatterns = [/rm\s+-rf/, />\s*\/dev/, /curl.*\|.*sh/, /wget.*\|.*sh/];
+    // 【実用上のセキュリティ強化】
+    // 本書に記載の危険パターン検知（dangerousPatterns）は簡易的なチェックです。
+    // 許可されたコマンドであっても、find -exec や git --git-dir のように、
+    // オプションや引数の値に危険なパラメータが指定されると検知をすり抜ける制限があります。
+    // このコードでは、実用上の安全性を高めるため、そうした危険なオプションもパターンに追加してブロックしています。
+    // 実務でサンドボックスなしで運用する場合は、実行可能なサブコマンドなどを厳しく絞り込む対策を推奨します。
+
+    // 本書には記述されていないが、rm -rf などの破壊的なコマンドや外部スクリプトの
+    // 実行、および危険なオプション指定を水際で防御するためのセキュリティ上の追加機能。
+    const dangerousPatterns = [
+        /rm\s+-rf/,
+        />\s*\/dev/,
+        /curl.*\|.*sh/,
+        /wget.*\|.*sh/,
+        /\s+--git-dir\b/,
+        /\s+--work-tree\b/,
+        /\s+-exec\b/,
+        /\s+-delete\b/
+    ];
     for (const pattern of dangerousPatterns) {
         if (pattern.test(commandForCheck)) {
             throw new Error('危険なコマンドパターンが検出されました');
         }
     }
 
+    // 4. パス引数の検証（ワークスペース内かチェック）
     for (const arg of commandArgs) {
+        // パスが '/' や '.' で始まる場合のトラバーサル漏れを防ぐためのセキュリティガード拡張。
         if (arg.startsWith('/') || arg.startsWith('.') || arg.includes('/') || arg.includes('\\')) {
             const resolvedPath = path.resolve(WORKSPACE_ROOT, arg);
             const allowedPrefix = WORKSPACE_ROOT + path.sep;
@@ -138,11 +192,12 @@ async function execCommandExecute(args: Record<string, unknown>): Promise<string
         }
     }
 
+    // 5. spawn()で実行（shell: falseでコマンドインジェクション対策）
     return new Promise((resolve, reject) => {
         const child = spawn(commandName, commandArgs, {
             cwd: WORKSPACE_ROOT,
             timeout: 30000,
-            shell: false,
+            shell: false, // シェルを介さない
         });
 
         let stdout = '';
@@ -180,6 +235,8 @@ async function execCommandExecute(args: Record<string, unknown>): Promise<string
                 // stderrは必ずしもエラーではない（gitはブランチ切替等をstderrに出力する）
                 resolve(stdout + (stderr ? `\n(stderr: ${stderr.trim()})` : ''));
             } else {
+                // コマンド失敗時 (code !== 0) に例外をスローすることで、
+                // 呼び出し元のエージェントが失敗を認識し、自律的に回復・修正行動を取れるようにしています。
                 reject(new Error(`コマンドが異常終了しました (exit code: ${code})\n${stderr}`));
             }
         });
@@ -190,17 +247,21 @@ async function execCommandExecute(args: Record<string, unknown>): Promise<string
     });
 }
 
+// ============================
+// ツール定義
+// ============================
 export const execCommand: Tool = {
     name: 'execCommand',
     description:
         'ワークスペース内で許可された汎用コマンドを実行する。利用可能：bun、ls、cat、grep、find、pwd、mkdir、git、gh。',
+    // ツール実行時に人間の承認が必要かどうか（第5章で使用）
     needsApproval: true,
     parameters: {
         type: 'object',
         properties: {
             command: {
                 type: 'string',
-                description: "実行するコマンド（例: 'bun test', 'ls -la'）",
+                description: '実行するコマンド（例: "bun test", "ls -la src/"）',
             },
         },
         required: ['command'],

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,11 +1,14 @@
-export { readFile } from './readFile';
-export { writeFile } from './writeFile';
-export { editFile } from './editFile';
-export { execCommand } from './execCommand';
-
 import { readFile } from './readFile';
 import { writeFile } from './writeFile';
 import { editFile } from './editFile';
 import { execCommand } from './execCommand';
 
-export const allTools = [readFile, writeFile, editFile, execCommand];
+export const allTools = [
+  readFile,
+  writeFile,
+  editFile,
+  execCommand,
+];
+
+// 他のモジュールから個々のツールオブジェクトを直接インポートできるようにするため、個別に再エクスポートを行っています。
+export { readFile, writeFile, editFile, execCommand };

--- a/src/tools/readFile.test.ts
+++ b/src/tools/readFile.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { readFile } from './readFile';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+
+describe('readFile Tool', () => {
+    const testFileName = 'test-read-file.txt';
+    const testFilePath = path.join(WORKSPACE_ROOT, testFileName);
+    const testContent = 'Hello, this is a test file for readFile tool.';
+
+    beforeAll(async () => {
+        await fs.mkdir(WORKSPACE_ROOT, { recursive: true });
+        await fs.writeFile(testFilePath, testContent, 'utf-8');
+    });
+
+    afterAll(async () => {
+        try {
+            await fs.unlink(testFilePath);
+        } catch {}
+    });
+
+    it('should read file inside workspace successfully', async () => {
+        const result = await readFile.execute({ path: testFileName });
+        expect(result).toBe(testContent);
+    });
+
+    it('should throw an error when file does not exist', async () => {
+        await expect(readFile.execute({ path: 'non-existent-file.txt' }))
+            .rejects.toThrow('ファイルが見つかりません');
+    });
+
+    it('should block reading file outside workspace (Path Traversal)', async () => {
+        await expect(readFile.execute({ path: '../package.json' }))
+            .rejects.toThrow('アクセス拒否');
+    });
+
+    it('should block reading symbolic link pointing outside workspace', async () => {
+        const symlinkName = 'bad-symlink.txt';
+        const symlinkPath = path.join(WORKSPACE_ROOT, symlinkName);
+        
+        try {
+            await fs.symlink(path.resolve(process.cwd(), './package.json'), symlinkPath);
+            await expect(readFile.execute({ path: symlinkName })).rejects.toThrow('アクセス拒否');
+        } finally {
+            try {
+                await fs.unlink(symlinkPath);
+            } catch {}
+        }
+    });
+
+    it('should block reading file exceeding max size limit', async () => {
+        const hugeFileName = 'huge-file.txt';
+        const hugeFilePath = path.join(WORKSPACE_ROOT, hugeFileName);
+        // 100KB超のファイルを書き込む (101KB = 101 * 1024)
+        const hugeContent = 'a'.repeat(101 * 1024);
+
+        try {
+            await fs.writeFile(hugeFilePath, hugeContent, 'utf-8');
+            await expect(readFile.execute({ path: hugeFileName })).rejects.toThrow('ファイルが大きすぎます');
+        } finally {
+            try {
+                await fs.unlink(hugeFilePath);
+            } catch {}
+        }
+    });
+});

--- a/src/tools/readFile.ts
+++ b/src/tools/readFile.ts
@@ -1,59 +1,76 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
+// ワークスペースのルートディレクトリを定義
 const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+
+// 読み込み可能なファイルサイズの上限（LLMのコンテキストウィンドウ保護）
 const MAX_FILE_SIZE = 100 * 1024; // 100KB
 
 async function readFileExecute(args: { path: string }): Promise<string> {
-    const absolutePath = path.resolve(WORKSPACE_ROOT, args.path);
+  // ステップ1: 相対パスを絶対パスに変換
+  const absolutePath = path.resolve(WORKSPACE_ROOT, args.path);
 
-    const allowedPrefix = WORKSPACE_ROOT + path.sep;
-    if (!absolutePath.startsWith(allowedPrefix) && absolutePath !== WORKSPACE_ROOT) {
-        throw new Error(`アクセス拒否: ${args.path} はワークスペース外です`);
+  // ステップ2: ワークスペース内かチェック（ディレクトリトラバーサル対策）
+  const allowedPrefix = WORKSPACE_ROOT + path.sep;
+  if (!absolutePath.startsWith(allowedPrefix) && absolutePath !== WORKSPACE_ROOT) {
+    throw new Error(`アクセス拒否: ${args.path} はワークスペース外です`);
+  }
+
+  // ステップ3: シンボリックリンクを解決して実パスを検証
+  let realPath: string;
+  try {
+    realPath = await fs.realpath(absolutePath);
+  } catch (error) {
+    if ((error as any).code === 'ENOENT') {
+      throw new Error(`ファイルが見つかりません: ${args.path}`);
     }
+    throw error;
+  }
 
-    // シンボリックリンクを解決して実パスを検証
-    const realPath = await fs.realpath(absolutePath);
-    if (!realPath.startsWith(allowedPrefix) && realPath !== WORKSPACE_ROOT) {
-        throw new Error(`アクセス拒否: ${args.path} はシンボリックリンク経由でワークスペース外を参照しています`);
+  if (!realPath.startsWith(allowedPrefix) && realPath !== WORKSPACE_ROOT) {
+    throw new Error(`アクセス拒否: ${args.path} はシンボリックリンク経由でワークスペース外を参照しています`);
+  }
+
+  // ステップ4: ファイル種別とサイズのチェック
+  try {
+    const stat = await fs.stat(absolutePath);
+    if (!stat.isFile()) {
+      throw new Error(`通常ファイルではありません: ${args.path}`);
     }
-
-    try {
-        const stat = await fs.stat(absolutePath);
-        // ファイル種別チェック
-        if (!stat.isFile()) {
-            throw new Error(`通常ファイルではありません: ${args.path}`);
-        }
-        if (stat.size > MAX_FILE_SIZE) {
-            throw new Error(
-                `ファイルが大きすぎます: ${args.path} (${Math.round(stat.size / 1024)}KB)。` +
-                `100KB以下のファイルのみ読み込めます。`
-            );
-        }
-
-        return await fs.readFile(absolutePath, 'utf-8');
-    } catch (error: any) {
-        if (error.code === 'ENOENT') {
-            throw new Error(`ファイルが見つかりません: ${args.path}`);
-        }
-        throw error;
+    if (stat.size > MAX_FILE_SIZE) {
+      throw new Error(
+        `ファイルが大きすぎます: ${args.path} (${Math.round(stat.size / 1024)}KB)。` +
+        `100KB以下のファイルのみ読み込めます。`
+      );
     }
+  } catch (error) {
+    // strictモードのビルドエラー回避のため as any を使用
+    if ((error as any).code === 'ENOENT') {
+      throw new Error(`ファイルが見つかりません: ${args.path}`);
+    }
+    throw error;
+  }
+
+  // ステップ5: ファイルの読み込み
+  const content = await fs.readFile(absolutePath, 'utf-8');
+  return content;
 }
 
 export const readFile = {
-    name: 'readFile',
-    description:
-        'ワークスペース内の指定されたパスのファイル内容を文字列として読み込む。ファイルが存在しない場合はエラーを返す。100KBを超える巨大ファイルは読み込めない（コンテキストウィンドウ保護のため）。相対パスまたは絶対パスを指定できる。',
-    needsApproval: false,
-    parameters: {
-        type: 'object',
-        properties: {
-            path: {
-                type: 'string',
-                description: "読み込むファイルのパス（例: 'README.md', 'src/index.ts'）",
-            },
-        },
-        required: ['path'],
+  name: "readFile",
+  description: "ワークスペース内の指定されたパスのファイル内容を文字列として読み込む。ファイルが存在しない場合はエラーを返す。100KBを超える巨大ファイルは読み込めない（コンテキストウィンドウ保護のため）。相対パスまたは絶対パスを指定できる。",
+  // ツール実行時に人間の承認が必要かどうか（第5章で使用）
+  needsApproval: false,
+  parameters: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "読み込むファイルのパス（例: 'README.md', 'src/index.ts'）"
+      }
     },
-    execute: readFileExecute,
+    required: ["path"]
+  },
+  execute: readFileExecute  // 上で実装した関数を紐付ける
 };

--- a/src/tools/writeFile.test.ts
+++ b/src/tools/writeFile.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { writeFile } from './writeFile';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
+
+describe('writeFile Tool', () => {
+    const testFileName = 'test-write-file.txt';
+    const testFilePath = path.join(WORKSPACE_ROOT, testFileName);
+
+    afterEach(async () => {
+        try {
+            await fs.unlink(testFilePath);
+        } catch {}
+        try {
+            await fs.unlink(path.join(WORKSPACE_ROOT, 'new-dir/nested.txt'));
+            await fs.rmdir(path.join(WORKSPACE_ROOT, 'new-dir'));
+        } catch {}
+    });
+
+    it('should write file inside workspace successfully', async () => {
+        const content = 'Hello, this is content written by writeFile tool.';
+        const result = await writeFile.execute({
+            path: testFileName,
+            content: content
+        });
+
+        expect(result).toContain(testFileName);
+        const writtenContent = await fs.readFile(testFilePath, 'utf-8');
+        expect(writtenContent).toBe(content);
+    });
+
+    it('should create directories recursively if they do not exist', async () => {
+        const nestedPath = 'new-dir/nested.txt';
+        const nestedFilePath = path.join(WORKSPACE_ROOT, nestedPath);
+        const content = 'Nested content';
+
+        const result = await writeFile.execute({
+            path: nestedPath,
+            content: content
+        });
+
+        expect(result).toContain(nestedPath);
+        const writtenContent = await fs.readFile(nestedFilePath, 'utf-8');
+        expect(writtenContent).toBe(content);
+    });
+
+    it('should block writing file outside workspace (Path Traversal)', async () => {
+        await expect(writeFile.execute({
+            path: '../outside.txt',
+            content: 'attempt'
+        })).rejects.toThrow('アクセス拒否');
+    });
+
+    it('should block writing file through symbolic link pointing outside workspace', async () => {
+        const symlinkName = 'bad-write-symlink.txt';
+        const symlinkPath = path.join(WORKSPACE_ROOT, symlinkName);
+        const targetPath = path.resolve(process.cwd(), './package.json');
+
+        try {
+            await fs.symlink(targetPath, symlinkPath);
+            await expect(writeFile.execute({
+                path: symlinkName,
+                content: 'malicious attempt'
+            })).rejects.toThrow('アクセス拒否');
+        } finally {
+            try {
+                await fs.unlink(symlinkPath);
+            } catch {}
+        }
+    });
+});

--- a/src/tools/writeFile.ts
+++ b/src/tools/writeFile.ts
@@ -4,50 +4,68 @@ import * as path from 'path';
 const WORKSPACE_ROOT = path.resolve(process.cwd(), './workspace');
 
 async function writeFileExecute(args: {
-    path: string;
-    content: string;
+  path: string;
+  content: string;
 }): Promise<string> {
-    const absolutePath = path.resolve(WORKSPACE_ROOT, args.path);
+  // ステップ1: 相対パスを絶対パスに変換
+  const absolutePath = path.resolve(WORKSPACE_ROOT, args.path);
 
-    const allowedPrefix = WORKSPACE_ROOT + path.sep;
-    if (!absolutePath.startsWith(allowedPrefix) && absolutePath !== WORKSPACE_ROOT) {
-        throw new Error(`アクセス拒否: ${args.path} はワークスペース外です`);
-    }
+  // ステップ2: ワークスペース内かチェック（ディレクトリトラバーサル対策）
+  const allowedPrefix = WORKSPACE_ROOT + path.sep;
+  if (!absolutePath.startsWith(allowedPrefix) && absolutePath !== WORKSPACE_ROOT) {
+    throw new Error(`アクセス拒否: ${args.path} はワークスペース外です`);
+  }
 
-    const dir = path.dirname(absolutePath);
-    await fs.mkdir(dir, { recursive: true });
-
+  // 【実用上のセキュリティ強化】
+  // 本書に記載の文字列比較（startsWith）のみでは、ワークスペース内に外部を指す
+  // シンボリックリンクが存在する場合にトラバーサルを許してしまう制限があります。
+  // そのため、ここでは実体パス（fs.realpath）がワークスペース内であることを検証します。
+  // ファイルが新規作成の場合は、存在する親ディレクトリまで遡って検証します。
+  let checkPath = absolutePath;
+  while (checkPath !== WORKSPACE_ROOT) {
     try {
-        await fs.access(absolutePath);
-        const backupPath = `${absolutePath}.backup`;
-        await fs.copyFile(absolutePath, backupPath);
-    } catch {
-        // ファイルが存在しない場合はバックアップ不要
+      const realPath = await fs.realpath(checkPath);
+      if (!realPath.startsWith(allowedPrefix) && realPath !== WORKSPACE_ROOT) {
+        throw new Error(`アクセス拒否: ${args.path} はシンボリックリンク経由でワークスペース外を参照しています`);
+      }
+      break;
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        checkPath = path.dirname(checkPath);
+      } else {
+        throw error;
+      }
     }
+  }
 
-    await fs.writeFile(absolutePath, args.content, 'utf-8');
+  // ステップ3: ディレクトリの作成（存在しない場合）
+  const dir = path.dirname(absolutePath);
+  await fs.mkdir(dir, { recursive: true });
 
-    return `ファイルを書き込みました: ${args.path}`;
+  // ステップ4: ファイルの書き込み
+  await fs.writeFile(absolutePath, args.content, 'utf-8');
+
+  return `ファイルを書き込みました: ${args.path}`;
 }
 
 export const writeFile = {
-    name: 'writeFile',
-    description:
-        '指定されたパスにファイルを作成または上書きする。既存ファイルは自動的にバックアップされる。ディレクトリが存在しない場合は自動的に作成される。',
-    needsApproval: true,
-    parameters: {
-        type: 'object',
-        properties: {
-            path: {
-                type: 'string',
-                description: '書き込むファイルのパス',
-            },
-            content: {
-                type: 'string',
-                description: 'ファイルに書き込む内容',
-            },
-        },
-        required: ['path', 'content'],
+  name: "writeFile",
+  description: "指定されたパスにファイルを作成または上書きする。ディレクトリが存在しない場合は自動的に作成される。",
+  // ツール実行時に人間の承認が必要かどうか（第5章で使用）
+  needsApproval: true,
+  parameters: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "書き込むファイルのパス"
+      },
+      content: {
+        type: "string",
+        description: "ファイルに書き込む内容"
+      }
     },
-    execute: writeFileExecute,
+    required: ["path", "content"]
+  },
+  execute: writeFileExecute
 };

--- a/workspace/docs/index.html
+++ b/workspace/docs/index.html
@@ -262,6 +262,8 @@
             </ul>
             <h3>第 4 章</h3>
             <ul>
+              <li><a href="#ch04-5-execcommand-security-extensions">4.5 節 execCommand の実用上のセキュリティ対策と機能拡張</a></li>
+              <li><a href="#ch04-6-tools-individual-exports">4.6 節 index.ts におけるツールの個別エクスポート</a></li>
               <li><a href="#ch04-6-tools-demo-filename">4.6 節 ツール動作確認スクリプトのファイル名</a></li>
             </ul>
             <h3>第 6 章</h3>
@@ -374,6 +376,86 @@ GOOGLE_API_KEY=AI...</code></pre>
 
           <section class="chapter-group">
             <h2>第 4 章</h2>
+
+            <article id="ch04-5-execcommand-security-extensions">
+              <header>
+                <span class="chapter-label">4.5 節</span>
+                <h3>execCommand の実用上のセキュリティ対策と機能拡張</h3>
+                <a class="anchor" href="#ch04-5-execcommand-security-extensions">#</a>
+              </header>
+              <dl>
+                <dt>概要</dt>
+                <dd>
+                  <p>配布リポジトリの <code>src/tools/execCommand.ts</code> は、本書に記載されたシンプルな実装と比較して、実用的な堅牢化（セキュリティ対策およびバグ防止）を施したコードになっています。</p>
+                </dd>
+                <dt>主な差異と追加意図</dt>
+                <dd>
+                  <ul>
+                    <li><strong>コマンド失敗時（<code>code !== 0</code>）の例外スロー：</strong><br>
+                      書籍では終了コードを文字列に含めて正常終了（<code>resolve</code>）させていますが、配布コードでは <code>reject(new Error)</code> により例外を投げるように変更しています。例外を投げない場合、エージェント側がコマンド失敗を認識できず、テストが落ちても「成功した」と思い込んで次のステップへ進むといった致命的なバグを防止するためです。
+                    </li>
+                    <li><strong><code>dangerousPatterns</code> 正規表現による危険パターン検知：</strong><br>
+                      書籍のホワイトリストチェックに加え、引数に <code>rm -rf</code> や <code>curl | sh</code> などの危険なパターンが渡された場合に水際でエラーを投げるセキュリティ防御層を追加しています。
+                    </li>
+                    <li><strong>引数オブジェクト（<code>commandName</code> / <code>commandArgs</code>）のサポート：</strong><br>
+                      Google (Gemini) や Anthropic のツール呼び出し時に、LLMが引数を文字列ではなくオブジェクトで返してくるケースがあるため、これらを安全に処理するための拡張です。
+                    </li>
+                    <li><strong>厳格なパス検証：</strong><br>
+                      引数内に含まれるパス指定が <code>/</code> や <code>.</code> で始まる場合のトラバーサル検知漏れを防ぐため、検証のロジックが強化されています。
+                    </li>
+                    <li><strong>許可コマンド（<code>ALLOWED_COMMANDS</code>）の追加：</strong><br>
+                      本書では <code>['bun', 'ls', 'git', 'gh']</code> のみが指定されていますが、第5章以降でエージェントが自律的にファイルの検索や閲覧（<code>grep</code>, <code>cat</code>, <code>find</code> 等）およびディレクトリ作成（<code>mkdir</code> 等）を行えるようにするため、あらかじめ許可される基本コマンドが追加されています。
+                    </li>
+                  </ul>
+                </dd>
+                <dt>実務におけるセキュリティ考慮事項と設計上の制限</dt>
+                <dd>
+                  <p>本書で解説しているツールのパス検証やコマンド制限は、コードをシンプルに保つために最小限のチェックにとどめています。実務において、サンドボックスなどの隔離環境を使用せずにツールを実行する場合、以下の設計制限（セキュリティ考慮事項）に留意し、必要に応じて強化策を実装してください。</p>
+                  <ul>
+                    <li><strong>シンボリックリンク経由のトラバーサル（writeFile / editFile）：</strong><br>
+                      文字列としてのプレフィックス比較（<code>startsWith</code>）だけでは、ワークスペース内にあらかじめ作成された、外部のファイルを指すシンボリックリンクを経由したファイルの上書きや閲覧（トラバーサル）を防げません。<br>
+                      実務でこの問題を回避するには、ファイルの操作前に <code>fs.realpath</code> を用いて実体パスを解決したうえで、その絶対パスがワークスペース内にあるかを検証する必要があります。
+                      <pre><code>// 対策コード例
+const realPath = await fs.realpath(absolutePath);
+if (!realPath.startsWith(allowedPrefix) &amp;&amp; realPath !== WORKSPACE_ROOT) {
+  throw new Error("アクセス拒否");
+}</code></pre>
+                    </li>
+                    <li><strong>コマンドオプションによる制限のすり抜け（execCommand）：</strong><br>
+                      <code>ALLOWED_COMMANDS</code> で <code>git</code> や <code>find</code> などの汎用的なコマンドの実行を許可している場合、<code>git --git-dir=../...</code> などのパス指定オプションや、<code>find -exec ...</code> などの別プロセス実行引数を利用されることで、単純なプレフィックスチェックや <code>dangerousPatterns</code> による正規表現検知をすり抜けて、ワークスペース外への干渉や任意コマンドの実行が行えてしまいます。<br>
+                      実務でサンドボックスを利用せずにコマンド実行ツールを使用する場合は、単にコマンド名を許可するだけでなく、実行可能なサブコマンド（例：<code>git commit</code> のみ）やオプションをホワイトリスト形式で厳密に絞り込むような追加の引数バリデーションが必要です。
+                    </li>
+                  </ul>
+                </dd>
+              </dl>
+            </article>
+
+            <article id="ch04-6-tools-individual-exports">
+              <header>
+                <span class="chapter-label">4.6 節</span>
+                <h3>index.ts におけるツールの個別エクスポート</h3>
+                <a class="anchor" href="#ch04-6-tools-individual-exports">#</a>
+              </header>
+              <dl>
+                <dt>概要</dt>
+                <dd>
+                  <p>配布リポジトリの <code>src/tools/index.ts</code> では、書籍の <code>allTools</code> 配列のエクスポートに加え、各ツールオブジェクト（<code>readFile</code>, <code>writeFile</code>, <code>editFile</code>, <code>execCommand</code>）が個別に再エクスポート（<code>export { ... }</code>）されています。</p>
+                </dd>
+                <dt>症状</dt>
+                <dd>
+                  <p>書籍のコード記述（<code>allTools</code> 配列のみをエクスポートする形）のまま、第 5 章以降の CLI 実行用スクリプト（<code>bin/cli.ts</code>）や他章のデモコードを動かそうとすると、特定のツールオブジェクトを直接個別にインポートしている箇所で次のような TypeScript のコンパイルエラーが発生します。</p>
+                  <pre><code>Module '"../src/tools"' declares 'readFile' locally, but it is not exported.</code></pre>
+                </dd>
+                <dt>対処</dt>
+                <dd>
+                  <p><code>src/tools/index.ts</code> の末尾に以下のエクスポート文を追記して、各ツールオブジェクトを個別に再エクスポートしてください。</p>
+                  <pre><code>export { readFile } from './readFile';
+export { writeFile } from './writeFile';
+export { editFile } from './editFile';
+export { execCommand } from './execCommand';</code></pre>
+                </dd>
+              </dl>
+            </article>
 
             <article id="ch04-6-tools-demo-filename">
               <header>


### PR DESCRIPTION
### 概要
書籍『作って学ぶAIエージェント』の第4章記述と配布リポジトリのコードとの整合性を向上させ、バグ修正やセキュリティ強化のために残した差異についてはコメントとサポートサイトに説明を追記しました。また、ツールの動作を保証する単体テストを追加しました。

### 変更点
1. **コードの整合性修正**:
   - `readFile.ts`, `writeFile.ts`, `editFile.ts` は書籍の解説コメントも含めて原稿と整合させ、不要なバックアップコピー処理などを削除。
   - `execCommand.ts` はマジックナンバーを書籍通り `2048` に戻し、残存する差異（引数のオブジェクト化、危険パターン検知、パス検証強化、例外スロー）に対して詳細な解説コメントを追記。
   - `chapters/04-tools-demo.ts` を書籍通りのステップ構成に完全再現。
   - `src/tools/index.ts` において、個別エクスポートをファイル末尾に再エクスポート形式で定義。
2. **単体テストコードの追加**:
   - 各ツール（`readFile`, `writeFile`, `editFile`, `execCommand`）に対する単体テストを新規作成し、正常系・異常系・セキュリティガードを検証。
3. **サポートサイト（ドキュメント）の更新**:
   - `workspace/docs/index.html` に第4章の「execCommand の実用上のセキュリティ対策と機能拡張」および「index.ts におけるツールの個別エクスポート」の補足説明を追記。
